### PR TITLE
chore: update to spring sdk 8.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 This project demonstrates the use of Spring Boot and [the Spring Zeebe SDK](https://docs.camunda.io/docs/apis-tools/spring-zeebe-sdk/getting-started/#add-the-spring-zeebe-sdk-to-your-project) to interact with a local Self-Managed Camunda installation.
 
-> [!WARNING]  
-> Due to a bug in 8.6, use the Spring Zeebe SDK version `8.5.0`.
-
 ## Written guide
 
 A guide for developing this project is available in the [Camunda docs][the-guide]. See that guide for step-by-step instructions and more detailed explanations.

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>io.camunda</groupId>
 			<artifactId>spring-boot-starter-camunda-sdk</artifactId>
-			<version>8.5.0</version>
+			<version>8.6.0</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,0 @@
-spring.application.name=process_payments
-
-zeebe.client.broker.grpcAddress=http://127.0.0.1:26500
-zeebe.client.broker.restAddress=http://127.0.0.1:8080
-zeebe.client.security.plaintext=true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,10 @@
+spring:
+  application:
+    name: process_payments
+camunda:
+  client:
+    mode: self-managed
+    zeebe:
+      enabled: true
+      grpc-address: http://localhost:26500
+      rest-address: http://localhost:8080


### PR DESCRIPTION
Bumps sdk dependency to 8.6.0 and adopts config to new properties https://docs.camunda.io/docs/apis-tools/spring-zeebe-sdk/getting-started/#self-managed .

Tested via `mvn spring-boot:run` with C8Run:

```
2024-10-09T08:17:15.498+02:00  INFO 20694 --- [process_payments] [           main] i.c.z.s.c.jobhandling.JobWorkerManager   : . Starting Zeebe worker: ZeebeWorkerValue{type='charge-credit-card', name='chargeCreditCardWorker#chargeCreditCard', timeout=PT-0.001S, maxJobsActive=-1, requestTimeout=PT-1S, pollInterval=PT-0.001S, autoComplete=true, fetchVariables=[totalWithTax], enabled=true, methodInfo=MethodInfo{classInfo=ClassInfo{beanName=chargeCreditCardWorker}, method=public java.util.Map io.camunda.demo.process_payments.ChargeCreditCardWorker.chargeCreditCard(java.lang.Double)}, tenantIds=[<default>], forceFetchAllVariables=false, streamEnabled=true, streamTimeout=PT1H, maxRetries=-1}
2024-10-09T08:17:15.504+02:00  INFO 20694 --- [process_payments] [           main] i.c.d.p.ProcessPaymentsApplication       : Started ProcessPaymentsApplication in 1.477 seconds (process running for 1.673)
2024-10-09T08:17:15.622+02:00  INFO 20694 --- [process_payments] [           main] i.c.d.p.ProcessPaymentsApplication       : started a process: 2251799813685402
2024-10-09T08:17:15.643+02:00  INFO 20694 --- [process_payments] [pool-2-thread-1] i.c.d.p.ChargeCreditCardWorker           : charging credit card: 120.0
```