### PR TITLE
debug: debug metrics registry warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,13 +37,25 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>io.camunda</groupId>
 			<artifactId>spring-boot-starter-camunda-sdk</artifactId>
-			<version>8.6.0</version>
+			<version>8.6.14-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/src/main/java/io/camunda/demo/process_payments/ProcessPaymentsApplication.java
+++ b/src/main/java/io/camunda/demo/process_payments/ProcessPaymentsApplication.java
@@ -11,10 +11,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.spring.client.annotation.Deployment;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 
 @SpringBootApplication
 @Deployment(resources = "classpath:process-payments.bpmn")
-public class ProcessPaymentsApplication implements CommandLineRunner {
+public class ProcessPaymentsApplication {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ProcessPaymentsApplication.class);
 
@@ -25,8 +27,8 @@ public class ProcessPaymentsApplication implements CommandLineRunner {
 		SpringApplication.run(ProcessPaymentsApplication.class, args);
 	}
 
-	@Override
-	public void run(final String... args) {
+	@EventListener(ApplicationReadyEvent.class)
+	public void doSomethingAfterStartup() {
 		var bpmnProcessId = "process-payments"; // or whatever the key is
 		var event = zeebeClient.newCreateInstanceCommand()
 				.bpmnProcessId(bpmnProcessId)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,3 +8,12 @@ camunda:
       enabled: true
       grpc-address: http://localhost:26500
       rest-address: http://localhost:8080
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+logging:
+  level:
+    io.micrometer.core.instrument.simple.SimpleMeterRegistry: DEBUG


### PR DESCRIPTION
This is not intended to get merged.

See https://github.com/camunda/camunda/issues/30812, this draft is used to verify the changes done with https://github.com/camunda/camunda/pull/31168 and requires a local build of the sdk until that PR is merged.

Startup is clear of warnings now
```
2025-04-17T09:56:18.003+02:00  INFO 15895 --- [process_payments] [           main] i.c.d.p.ProcessPaymentsApplication       : Starting ProcessPaymentsApplication using Java 21.0.6 with PID 15895 (/Users/sebastian.bathke/git/camunda-8-get-started-spring/target/classes started by sebastian.bathke in /Users/sebastian.bathke/git/camunda-8-get-started-spring)
2025-04-17T09:56:18.004+02:00  INFO 15895 --- [process_payments] [           main] i.c.d.p.ProcessPaymentsApplication       : No active profile set, falling back to 1 default profile: "default"
2025-04-17T09:56:18.295+02:00  INFO 15895 --- [process_payments] [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port 8080 (http)
2025-04-17T09:56:18.299+02:00  INFO 15895 --- [process_payments] [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
2025-04-17T09:56:18.299+02:00  INFO 15895 --- [process_payments] [           main] o.apache.catalina.core.StandardEngine    : Starting Servlet engine: [Apache Tomcat/10.1.24]
2025-04-17T09:56:18.311+02:00  INFO 15895 --- [process_payments] [           main] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring embedded WebApplicationContext
2025-04-17T09:56:18.311+02:00  INFO 15895 --- [process_payments] [           main] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 296 ms
2025-04-17T09:56:18.381+02:00  INFO 15895 --- [process_payments] [           main] z.s.c.c.ZeebeClientProdAutoConfiguration : Creating ZeebeClient using ZeebeClientConfigurationImpl [ZeebeClientConfigurationImpl{properties=ZeebeClientConfigurationProperties{environment=ApplicationServletEnvironment {activeProfiles=[], defaultProfiles=[default], propertySources=[ConfigurationPropertySourcesPropertySource {name='configurationProperties'}, StubPropertySource {name='servletConfigInitParams'}, ServletContextPropertySource {name='servletContextInitParams'}, PropertiesPropertySource {name='systemProperties'}, OriginAwareSystemEnvironmentPropertySource {name='systemEnvironment'}, RandomValuePropertySource {name='random'}, OriginTrackedMapPropertySource {name='Config resource 'class path resource [application.yml]' via location 'optional:classpath:/''}, OriginTrackedMapPropertySource {name='application-camunda-self-managed.yaml'}]}, connectionMode='null', defaultTenantId='<default>', defaultJobWorkerTenantIds=[<default>], applyEnvironmentVariableOverrides=false, enabled=true, broker=Broker{gatewayAddress='null, grpcAddress=null, restAddress=null, keepAlive=PT45S}, cloud=Cloud{clusterId='null', clientId='***', clientSecret='***', region='bru-2', scope='null', baseUrl='zeebe.camunda.io', authUrl='https://login.cloud.camunda.io/oauth/token', port=443, credentialsCachePath='null'}, worker=Worker{maxJobsActive=32, threads=1, defaultName='null', defaultType='null', override={}}, message=Message{timeToLive=PT1H, maxMessageSize=5242880}, security=Security{plaintext=null, overrideAuthority='null', certPath='null'}, job=Job{timeout=PT5M, pollInterval=PT0.1S}, ownsJobWorkerExecutor=false, defaultJobWorkerStreamEnabled=false, requestTimeout=PT10S}, camundaClientProperties=io.camunda.zeebe.spring.client.properties.CamundaClientProperties@32a4ecbe, jsonMapper=io.camunda.zeebe.client.impl.ZeebeObjectMapper@2e71240b, interceptors=[], chainHandlers=[], zeebeClientExecutorService=io.camunda.zeebe.spring.client.jobhandling.ZeebeClientExecutorService@23cd5d42}]
2025-04-17T09:56:18.543+02:00  INFO 15895 --- [process_payments] [           main] i.c.z.s.c.a.MicrometerMetricsRecorder    : Enabling Micrometer based metrics for spring-zeebe (available via Actuator)
2025-04-17T09:56:18.617+02:00  INFO 15895 --- [process_payments] [           main] o.s.b.a.e.web.EndpointLinksResolver      : Exposing 15 endpoints beneath base path '/actuator'
2025-04-17T09:56:18.634+02:00  INFO 15895 --- [process_payments] [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port 8080 (http) with context path '/'
2025-04-17T09:56:18.635+02:00  INFO 15895 --- [process_payments] [           main] c.a.p.ZeebeDeploymentAnnotationProcessor : Configuring deployment: ZeebeDeploymentValue{resources=[classpath:process-payments.bpmn], beanInfo=ClassInfo{beanName=processPaymentsApplication}}
2025-04-17T09:56:18.636+02:00  INFO 15895 --- [process_payments] [           main] z.s.c.a.p.ZeebeWorkerAnnotationProcessor : Configuring 1 Zeebe worker(s) of bean 'chargeCreditCardWorker': [ZeebeWorkerValue{type='charge-credit-card', name='', timeout=PT-0.001S, maxJobsActive=-1, requestTimeout=PT-1S, pollInterval=PT-0.001S, autoComplete=true, fetchVariables=[], enabled=true, methodInfo=MethodInfo{classInfo=ClassInfo{beanName=chargeCreditCardWorker}, method=public java.util.Map io.camunda.demo.process_payments.ChargeCreditCardWorker.chargeCreditCard(java.lang.Double)}, tenantIds=[], forceFetchAllVariables=false, streamEnabled=false, streamTimeout=PT1H, maxRetries=-1}]
2025-04-17T09:56:18.651+02:00  INFO 15895 --- [process_payments] [           main] i.c.z.s.c.jobhandling.JobWorkerManager   : . Starting Zeebe worker: ZeebeWorkerValue{type='charge-credit-card', name='chargeCreditCardWorker#chargeCreditCard', timeout=PT-0.001S, maxJobsActive=-1, requestTimeout=PT-1S, pollInterval=PT-0.001S, autoComplete=true, fetchVariables=[totalWithTax], enabled=true, methodInfo=MethodInfo{classInfo=ClassInfo{beanName=chargeCreditCardWorker}, method=public java.util.Map io.camunda.demo.process_payments.ChargeCreditCardWorker.chargeCreditCard(java.lang.Double)}, tenantIds=[<default>], forceFetchAllVariables=false, streamEnabled=false, streamTimeout=PT1H, maxRetries=0}
2025-04-17T09:56:18.757+02:00  INFO 15895 --- [process_payments] [           main] c.a.p.ZeebeDeploymentAnnotationProcessor : Deployed: <process-payments:1>
2025-04-17T09:56:18.763+02:00  INFO 15895 --- [process_payments] [           main] i.c.d.p.ProcessPaymentsApplication       : Started ProcessPaymentsApplication in 0.856 seconds (process running for 6.065)
2025-04-17T09:56:18.787+02:00  INFO 15895 --- [process_payments] [           main] i.c.d.p.ProcessPaymentsApplication       : started a process: 2251799813685417
2025-04-17T09:56:18.799+02:00  INFO 15895 --- [process_payments] [pool-1-thread-1] i.c.d.p.ChargeCreditCardWorker           : charging credit card: 120.0
2025-04-17T09:56:18.918+02:00  INFO 15895 --- [process_payments] [192.168.123.165] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring DispatcherServlet 'dispatcherServlet'
2025-04-17T09:56:18.918+02:00  INFO 15895 --- [process_payments] [192.168.123.165] o.s.web.servlet.DispatcherServlet        : Initializing Servlet 'dispatcherServlet'
2025-04-17T09:56:18.919+02:00  INFO 15895 --- [process_payments] [192.168.123.165] o.s.web.servlet.DispatcherServlet        : Completed initialization in 1 ms
```

Still standard metrics like jvm are present on `http://localhost:8080/actuator/prometheus`:
```
# HELP application_ready_time_seconds Time taken for the application to be ready to service requests
# TYPE application_ready_time_seconds gauge
application_ready_time_seconds{main_application_class="io.camunda.demo.process_payments.ProcessPaymentsApplication"} 0.859
# HELP application_started_time_seconds Time taken to start the application
# TYPE application_started_time_seconds gauge
application_started_time_seconds{main_application_class="io.camunda.demo.process_payments.ProcessPaymentsApplication"} 0.856
# HELP camunda_job_invocations_total  
# TYPE camunda_job_invocations_total counter
camunda_job_invocations_total{action="activated",type="charge-credit-card"} 1.0
camunda_job_invocations_total{action="completed",type="charge-credit-card"} 1.0
# HELP disk_free_bytes Usable space for path
# TYPE disk_free_bytes gauge
disk_free_bytes{path="/Users/sebastian.bathke/git/camunda-8-get-started-spring/."} 3.48296105984E11
# HELP disk_total_bytes Total space for path
# TYPE disk_total_bytes gauge
disk_total_bytes{path="/Users/sebastian.bathke/git/camunda-8-get-started-spring/."} 4.94384795648E11
# HELP executor_active_threads The approximate number of threads that are actively executing tasks
# TYPE executor_active_threads gauge
executor_active_threads{name="applicationTaskExecutor"} 0.0
executor_active_threads{name="zeebe_client_thread_pool"} 0.0
# HELP executor_completed_tasks_total The approximate total number of tasks that have completed execution
# TYPE executor_completed_tasks_total counter
executor_completed_tasks_total{name="applicationTaskExecutor"} 0.0
executor_completed_tasks_total{name="zeebe_client_thread_pool"} 2.0
# HELP executor_pool_core_threads The core number of threads for the pool
# TYPE executor_pool_core_threads gauge
executor_pool_core_threads{name="applicationTaskExecutor"} 8.0
executor_pool_core_threads{name="zeebe_client_thread_pool"} 1.0
# HELP executor_pool_max_threads The maximum allowed number of threads in the pool
# TYPE executor_pool_max_threads gauge
executor_pool_max_threads{name="applicationTaskExecutor"} 2.147483647E9
executor_pool_max_threads{name="zeebe_client_thread_pool"} 2.147483647E9
# HELP executor_pool_size_threads The current number of threads in the pool
# TYPE executor_pool_size_threads gauge
executor_pool_size_threads{name="applicationTaskExecutor"} 0.0
executor_pool_size_threads{name="zeebe_client_thread_pool"} 1.0
# HELP executor_queue_remaining_tasks The number of additional elements that this queue can ideally accept without blocking
# TYPE executor_queue_remaining_tasks gauge
executor_queue_remaining_tasks{name="applicationTaskExecutor"} 2.147483647E9
executor_queue_remaining_tasks{name="zeebe_client_thread_pool"} 2.147483647E9
# HELP executor_queued_tasks The approximate number of tasks that are queued for execution
# TYPE executor_queued_tasks gauge
executor_queued_tasks{name="applicationTaskExecutor"} 0.0
executor_queued_tasks{name="zeebe_client_thread_pool"} 0.0
# HELP http_server_requests_active_seconds  
# TYPE http_server_requests_active_seconds summary
http_server_requests_active_seconds_count{exception="none",method="GET",outcome="SUCCESS",status="200",uri="UNKNOWN"} 1
http_server_requests_active_seconds_sum{exception="none",method="GET",outcome="SUCCESS",status="200",uri="UNKNOWN"} 0.025351541
# HELP http_server_requests_active_seconds_max  
# TYPE http_server_requests_active_seconds_max gauge
http_server_requests_active_seconds_max{exception="none",method="GET",outcome="SUCCESS",status="200",uri="UNKNOWN"} 0.025365
# HELP jvm_info JVM version info
# TYPE jvm_info gauge
jvm_info{runtime="OpenJDK Runtime Environment",vendor="Eclipse Adoptium",version="21.0.6+7-LTS"} 1
# HELP jvm_buffer_count_buffers An estimate of the number of buffers in the pool
# TYPE jvm_buffer_count_buffers gauge
jvm_buffer_count_buffers{id="direct"} 14.0
...
```